### PR TITLE
Fix async image conversion to properly handle all images

### DIFF
--- a/src/HtmlRenderer.ts
+++ b/src/HtmlRenderer.ts
@@ -54,18 +54,22 @@ export default class HtmlRenderer {
     });
 
     // Convert images to base 64 strings.
-    el.querySelectorAll('img').forEach(async (img) => {
+    const imgElements = Array.from(el.querySelectorAll('img'));
+    const imgPromises = imgElements.map(async (img) => {
       const src = img.src;
       if (src !== null && src !== undefined) {
         img.src = await this.convertImageToBase64String(src);
       }
     });
 
+    // Wait for all image conversions to complete
+    await Promise.all(imgPromises);
+
     /**
      * Wait some time to let the browser finish the painting flow.
      * Explanation: https://macarthur.me/posts/when-dom-updates-appear-to-be-asynchronous/
      */
-    await new Promise((resolve, reject) => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         resolve(null);
       }, 100);


### PR DESCRIPTION
When exporting to HTML, only the first image would render correctly because the code wasn't properly awaiting all image conversions to complete. Modified the image processing to:

1. Collect all img elements into an array
2. Create promises for each image conversion
3. Use Promise.all to wait for all conversions to complete before continuing

Also removed unused reject parameter in the setTimeout Promise.

Tested on my local machine, but as I'm new to Obsidian, additional testing recommended.